### PR TITLE
Chewbbaca batch input

### DIFF
--- a/modules/ariba/main.nf
+++ b/modules/ariba/main.nf
@@ -55,7 +55,7 @@ process ariba_run {
   script:
     outputName = params.outdir ? params.outdir : "ariba_output"
     """
-    ariba run ${args.join(' ')} --threads ${task.cpus} ${referenceDir} ${reads.join(' ')} ${outputName}
+    ariba run ${args.join(' ')} --force --threads ${task.cpus} ${referenceDir} ${reads.join(' ')} ${outputName}
     cp ${outputName}/report.tsv ${sampleName}_ariba_report.tsv
     """
 }

--- a/modules/bwa/main.nf
+++ b/modules/bwa/main.nf
@@ -23,7 +23,7 @@ process bwa_index {
 
   script:
     """
-    bwa index ${reference}
+    bwa index ${reference} ${reference.baseName}/${reference}
     """
 }
 

--- a/modules/chewbbaca/main.nf
+++ b/modules/chewbbaca/main.nf
@@ -32,18 +32,15 @@ process chewbbaca_allelecall {
   script:
     missingLoci = "chewbbaca.missingloci"
     trainingFile = trainingFile ? "--ptf ${trainingFile}" : "" 
-    flockfile = file(params.localTempDir + '/chewbbaca.lock') 
-    flocking = flockfile.exists() ? "flock -e $flockfile \\" : ""
 
     """
-    ${flocking}
-      chewie AlleleCall \\
-      -i ${batchInput} \\
-      ${params.args.join(' ')} \\
-      --cpu ${task.cpus} \\
-      --output-directory output_dir \\
-      ${trainingFile} \\
-      --schema-directory ${schemaDir}
+    chewie AlleleCall \\
+    -i ${batchInput} \\
+    ${params.args.join(' ')} \\
+    --cpu ${task.cpus} \\
+    --output-directory output_dir \\
+    ${trainingFile} \\
+    --schema-directory ${schemaDir}
     #bash parse_missing_loci.sh batch_input.list 'output_dir/*/results_alleles.tsv' ${missingLoci}
     """
 }
@@ -62,7 +59,6 @@ process chewbbaca_create_batch_list {
 
   script:
     output = "batch_input.list"
-    //for i in $maskedAssembly ; do echo -e "\$PWD/\$i" >> $output ; done
     """
     realpath $maskedAssembly > $output
     """
@@ -83,7 +79,6 @@ process chewbbaca_split_results {
     tuple val(sampleName), path("${output}")
 
   script:
-    id = "${input.simpleName}"
     output = "${sampleName}.chewbbaca"
     """
     head -1 ${input} > ${output}

--- a/modules/chewbbaca/main.nf
+++ b/modules/chewbbaca/main.nf
@@ -30,10 +30,13 @@ process chewbbaca_allelecall {
   script:
     output = "${sampleName}.vcf"
     missingLoci = "chewbbaca.missingloci"
-    trainingFile = trainingFile ? "--ptf ${trainingFile}" : ""
+    trainingFile = trainingFile ? "--ptf ${trainingFile}" : "" 
+    flockfile = file(params.localTempDir + '/chewbbaca.lock') 
+    flocking = flockfile.exists() ? "flock -e $flockfile \\" : ""
+
     """
     echo ${input} > batch_input.list
-    flock -e ${params.localTempDir}/chewbbaca.lock \\
+    ${flocking}
       chewBBACA.py AlleleCall \\
       -i batch_input.list \\
       ${params.args.join(' ')} \\

--- a/modules/cmd/main.nf
+++ b/modules/cmd/main.nf
@@ -164,7 +164,7 @@ process save_analysis_metadata {
   script:
     output = "${workflow.runName}_analysis_meta.json"
     """
-    #!/usr/bin/python
+    #!/usr/bin/env python
     import json
 
     res = {

--- a/modules/cmd/main.nf
+++ b/modules/cmd/main.nf
@@ -156,8 +156,6 @@ process save_analysis_metadata {
     mode: params.publishDirMode, 
     overwrite: params.publishDirOverwrite
 
-  input:
-
   output:
     path(output)
 

--- a/modules/resfinder/main.nf
+++ b/modules/resfinder/main.nf
@@ -44,15 +44,16 @@ process resfinder {
     POINT_DB_HASH=\$(git -C ${pointfinderDb} rev-parse HEAD)
     JSON_FMT='[{"name": "%s", "version": "%s", "type": "%s"},{"name": "%s", "version": "%s", "type": "%s"}]'
     printf "\$JSON_FMT" "resfinder" \$RES_DB_HASH "database" "pointfinder" \$POINT_DB_HASH "database" > $metaFile
-    # Get resfinder path
-    RESF=\$(which run_resfinder.py)
 
     # Run resfinder
-    \$RESF                          \\
+    python -m resfinder             \\
     --inputfastq ${reads.join(' ')} \\
     ${specieArgs}                   \\
     ${resfinderFinderParams}        \\
-    ${pointFinderParams}
+    ${pointFinderParams}            \\
+    --out_json std_format_under_development.json  \\
+    --outputPath .
+
     cp std_format_under_development.json ${outputFileJson}
     cp pheno_table.txt ${outputFileGene}
     cp PointFinder_results.txt ${outputFilePoint}

--- a/modules/resfinder/main.nf
+++ b/modules/resfinder/main.nf
@@ -21,8 +21,8 @@ process resfinder {
   input:
     tuple val(sampleName), path(reads)
     val specie
-    path resfinderDb
-    path pointfinderDb
+    val resfinderDb
+    val pointfinderDb
 
   output:
     tuple val(sampleName), path(outputFileJson), emit: json


### PR DESCRIPTION
The following changes were made:
* bwa output filepath was changed to avoid error listed in this [issue](https://github.com/nf-core/chipseq/issues/65).
* chewbbaca batch input list generator was created to avoid multiple processes competing for the same databases whilst running in parallel ([issue](https://github.com/B-UMMI/chewBBACA/issues/11)).
* Modules involved in chewbbaca were updated to separate the resulting chewbbaca batch output.